### PR TITLE
Resource api

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -6,6 +6,8 @@
 namespace tlsf {
 namespace detail {
 
+//More ergonomic cast
+//TODO: may want to change this to reinterpret_cast or static_cast depending on context. 
 #define TLSF_CAST(t, exp) ((t)(exp))
 
 /**
@@ -245,7 +247,7 @@ block_header* block_header::from_void_ptr(const void* ptr){
  */
 block_header* block_header::offset_to_block(const void* ptr, tlsfptr_t blk_size){
     auto result = TLSF_CAST(block_header*, TLSF_CAST(tlsfptr_t, ptr)+blk_size);
-    fprintf(stderr, "Address of header: %p\n", result);
+    // fprintf(stderr, "Address of header: %p\n", result);
     return result;
 }
 

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -1,10 +1,8 @@
 #include "pool.hpp"
 #include <cstddef>
-#include <cstdint>
 #include <climits>
 #include <cassert>
 #include <cstring>
-#include <iostream>
 #include <memory_resource>
 
 // More ergonomic cast
@@ -20,20 +18,77 @@ static_assert(sizeof(size_t) * CHAR_BIT <= 64);
 using tlsfptr_t = std::ptrdiff_t; 
 
 
+std::optional<tlsf_pool> tlsf_pool::create(std::size_t bytes, std::pmr::memory_resource* upstream) {
+    tlsf_pool pool(bytes, upstream);
+
+    //Constructor will set memory_pool to nullptr on failure.
+    //Check that initialization was successful.
+    if (!pool.is_allocated()) {
+        return std::nullopt;
+    }
+    //pool is move constructed inside optional object otherwise.
+    return pool; 
+}
+
+std::optional<tlsf_pool> tlsf_pool::create(pool_options options) {
+    return tlsf_pool::create(options.size, options.upstream_resource);
+}
+
+tlsf_pool::tlsf_pool(std::size_t bytes, std::pmr::memory_resource* upstream): upstream(upstream) {
+    this->initialize(bytes);
+}
+
+tlsf_pool::tlsf_pool(tlsf_pool&& other) noexcept: 
+    memory_pool(other.memory_pool), 
+    upstream(other.upstream), 
+    pool_size(other.pool_size),
+    allocated_size(other.allocated_size),
+    block_null(other.block_null),
+    fl_bitmap(other.fl_bitmap) 
+{
+    std::memcpy(sl_bitmap, other.sl_bitmap, sizeof(sl_bitmap));
+    std::memcpy(blocks, other.blocks, sizeof(blocks));
+
+    // IMPORTANT: nullify the moved-from object's pointer to prevent double-free
+    other.memory_pool = nullptr;
+    other.pool_size = 0;
+    other.allocated_size = 0;
+
+}
+
+tlsf_pool& tlsf_pool::operator=(tlsf_pool&& other) noexcept {
+    if (this != &other) {
+        if (this->memory_pool) {
+            this->upstream->deallocate(this->memory_pool, this->allocated_size, ALIGN_SIZE);
+        }
+        this->memory_pool = other.memory_pool;
+        this->upstream = other.upstream;
+        this->pool_size = other.pool_size;
+        this->allocated_size = other.allocated_size;
+        this->block_null = other.block_null;
+        this->fl_bitmap = other.fl_bitmap;
+        std::memcpy(sl_bitmap, other.sl_bitmap, sizeof(sl_bitmap));
+        std::memcpy(blocks, other.blocks, sizeof(blocks));
+
+        //IMPORTANT: nullify the moved-from object's pointer to prevent double-free
+        other.memory_pool = nullptr;
+        other.pool_size = 0;
+        other.allocated_size = 0;
+    }
+    return *this;
+}
+
 tlsf_pool::~tlsf_pool(){
     if (this->memory_pool){
-        this->upstream->deallocate((void*)(this->memory_pool), this->allocated_size, ALIGN_SIZE);
+        this->upstream->deallocate(static_cast<void*>(this->memory_pool), this->allocated_size, ALIGN_SIZE);
         this->memory_pool = nullptr;
     }
 }
 
-void tlsf_pool::initialize(std::size_t size){
-    //TODO: currently this allocator uses malloc to allocate memory for the pool, 
-    //but we should use some kind of function pointer or template instead to use other means of memory allocation.
-    this->memory_pool = (char*) this->upstream->allocate(size, ALIGN_SIZE);
-    this->allocated_size = size;
-    //Create a reference null block. 
-    //Pointing to this block will indicate that this block pointer is not assigned.
+void tlsf_pool::initialize(std::size_t bytes){
+    this->allocated_size = bytes;
+    void* allocated_mem = this->upstream->allocate(bytes, ALIGN_SIZE);
+
     block_null = block_header();
     block_null.next_free = &block_null;
     block_null.prev_free = &block_null;
@@ -44,12 +99,21 @@ void tlsf_pool::initialize(std::size_t size){
     for (int i = 0; i < FL_INDEX_COUNT; ++i){
         this->sl_bitmap[i] = 0;
         for (int j = 0; j < SL_INDEX_COUNT; ++j){
-
             this->blocks[i][j] = &block_null;
         }
     }
 
-     this->create_memory_pool(this->memory_pool + BLOCK_HEADER_OVERHEAD, size-BLOCK_HEADER_OVERHEAD);
+    //If initialization fails, a nullptr will be returned.
+    char* pool_start = this->create_memory_pool(
+        static_cast<char*>(allocated_mem) + BLOCK_HEADER_OVERHEAD,
+        this->allocated_size - BLOCK_HEADER_OVERHEAD
+    );
+
+    if (pool_start == nullptr) {
+        this->upstream->deallocate(allocated_mem, this->allocated_size, ALIGN_SIZE);
+    } else {
+        this->memory_pool = static_cast<char*>(allocated_mem);
+    }
 }
 
 char* tlsf_pool::create_memory_pool(char* mem, std::size_t bytes){
@@ -57,26 +121,18 @@ char* tlsf_pool::create_memory_pool(char* mem, std::size_t bytes){
     block_header* next;
 
     const std::size_t pool_bytes = align_down(bytes - POOL_OVERHEAD, ALIGN_SIZE);
-    this->pool_size = pool_bytes;
-
+    
     if (((ptrdiff_t)mem % ALIGN_SIZE) != 0){
         //memory size is not aligned
-        // fprintf(stderr,"tlsf init pool: Memory size must be aligned by %u bytes.\n", (unsigned int)ALIGN_SIZE);
-        std::cerr << "tlsf init pool: Memory size must be aligned by " << static_cast<unsigned int>(ALIGN_SIZE) << " bytes.\n";
         return nullptr;
     }
-
+    
     if (pool_bytes < BLOCK_SIZE_MIN || pool_bytes > BLOCK_SIZE_MAX){
-#ifdef TLSF_64BIT
-            std::cerr << "Init pool: Memory size must be between 0x" << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MIN) 
-                << " and 0x" << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MAX) << "00 bytes.\n";
-#else
-            std::cerr << "Init pool: Memory size must be between " << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MIN) 
-                << " and " << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MAX) << " bytes.\n";
-#endif
+        //pool bytes are out of range of block size requirements
         return nullptr;
     }
-
+    this->pool_size = pool_bytes;
+    
     // create the main free block. Offset the start of the block slightly
     // so that the prev_phys_free_block field falls outside of the pool - 
     // it will never be used.

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -4,6 +4,7 @@
 #include <climits>
 #include <cassert>
 #include <cstring>
+#include <iostream>
 #include <memory_resource>
 
 // More ergonomic cast
@@ -60,19 +61,18 @@ char* tlsf_pool::create_memory_pool(char* mem, std::size_t bytes){
 
     if (((ptrdiff_t)mem % ALIGN_SIZE) != 0){
         //memory size is not aligned
-        printf("tlsf init pool: Memory size must be aligned by %u bytes.\n", (unsigned int)ALIGN_SIZE);
+        // fprintf(stderr,"tlsf init pool: Memory size must be aligned by %u bytes.\n", (unsigned int)ALIGN_SIZE);
+        std::cerr << "tlsf init pool: Memory size must be aligned by " << static_cast<unsigned int>(ALIGN_SIZE) << " bytes.\n";
         return nullptr;
     }
 
     if (pool_bytes < BLOCK_SIZE_MIN || pool_bytes > BLOCK_SIZE_MAX){
 #ifdef TLSF_64BIT
-            printf("Init pool: Memory size must be between 0x%x and 0x%x00 bytes.\n",
-                (unsigned int)(POOL_OVERHEAD+BLOCK_SIZE_MIN),
-                (unsigned int)(POOL_OVERHEAD+BLOCK_SIZE_MAX));
+            std::cerr << "Init pool: Memory size must be between 0x" << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MIN) 
+                << " and 0x" << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MAX) << "00 bytes.\n";
 #else
-            printf("Init pool: Memory size must be between %u and %u bytes.\n",
-                (unsigned int)(POOL_OVERHEAD+BLOCK_SIZE_MIN),
-                (unsigned int)(POOL_OVERHEAD+BLOCK_SIZE_MAX));
+            std::cerr << "Init pool: Memory size must be between " << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MIN) 
+                << " and " << static_cast<unsigned int>(POOL_OVERHEAD+BLOCK_SIZE_MAX) << " bytes.\n";
 #endif
         return nullptr;
     }

--- a/src/pool.hpp
+++ b/src/pool.hpp
@@ -23,19 +23,21 @@ class tlsf_pool {
 
     public:
         static constexpr std::size_t DEFAULT_POOL_SIZE = 1024*1024;
-
-
+        
         explicit tlsf_pool(std::size_t bytes){ this->initialize(bytes); }
         explicit tlsf_pool() { this->initialize(DEFAULT_POOL_SIZE); }
         explicit tlsf_pool(pool_options options) : upstream(options.upstream_resource) 
             {this->initialize(options.size); }
+
+        //copy construction is disabled
+        tlsf_pool(const tlsf_pool&) = delete;
+        tlsf_pool& operator=(const tlsf_pool&) = delete;
 
         ~tlsf_pool();
 
         void* malloc_pool(std::size_t size);
         bool free_pool(void* ptr);
         void* realloc_pool(void* ptr, std::size_t size);
-         
         void* memalign_pool(std::size_t align, std::size_t size);
 
         

--- a/src/pool.hpp
+++ b/src/pool.hpp
@@ -1,8 +1,7 @@
 #pragma once
 #include "block.hpp"
-#include <cstddef>
-#include <cassert>
 #include <memory_resource>
+#include <optional>
 
 namespace tlsf {
 
@@ -13,42 +12,88 @@ struct pool_options {
 
 /**
  * @brief Memory pool that allocates following the TLSF algorithm, and contains 
- * all the internal implementation details. Unless you are implementing your own memory resource 
- * or need the lower-level control, you should use `tlsf_resource` or 
- * `synchronized_tlsf_resource` instead. 
+ * all the internal implementation details. It uses RAII to automatically free the 
+ * memory allocated for the pool when it exits the scope. Unless you are implementing 
+ * your own memory resource or need the lower-level control, you should use 
+ * `tlsf_resource` or `synchronized_tlsf_resource` instead. 
  * 
  * @warning Make sure the pool outlives any objects whose memory is allocated by it! Failure to do so will result in dangling pointers.
  */
 class tlsf_pool {
 
     public:
-        static constexpr std::size_t DEFAULT_POOL_SIZE = 1024*1024;
+    static constexpr std::size_t DEFAULT_POOL_SIZE = 1024*1024;
+    
+    /**
+     * @brief Create a TLSF memory pool by allocating `bytes` of heap memory. This is the main way 
+     * to create a TLSF memory pool. 
+     * 
+     * @param bytes Size of the memory pool, in bytes
+     * @param upstream Memory resource to allocate/deallocate memory from. By default, uses `new` and `delete`. 
+     * 
+     * @returns The memory pool object if initialization was successful, `std::nullopt` otherwise.
+     */
+    static std::optional<tlsf_pool> create(
+        std::size_t bytes = DEFAULT_POOL_SIZE, 
+        std::pmr::memory_resource* upstream = std::pmr::new_delete_resource());
+    
+    /**
+     * @brief Create a TLSF memory pool by allocating `bytes` of heap memory. This is the main way 
+     * to create a TLSF memory pool. 
+     * 
+     * @param options Options for the memory pool.
+     * 
+     * @returns The memory pool object if initialization was successful, `std::nullopt` otherwise.
+     */
+    static std::optional<tlsf_pool> create(pool_options options);
         
-        explicit tlsf_pool(std::size_t bytes){ this->initialize(bytes); }
-        explicit tlsf_pool() { this->initialize(DEFAULT_POOL_SIZE); }
-        explicit tlsf_pool(pool_options options) : upstream(options.upstream_resource) 
-            {this->initialize(options.size); }
-
         //copy construction is disabled
         tlsf_pool(const tlsf_pool&) = delete;
         tlsf_pool& operator=(const tlsf_pool&) = delete;
 
+        tlsf_pool(tlsf_pool&& pool) noexcept;
+        tlsf_pool& operator=(tlsf_pool&& other) noexcept;
+        
         ~tlsf_pool();
-
+        
         void* malloc_pool(std::size_t size);
         bool free_pool(void* ptr);
         void* realloc_pool(void* ptr, std::size_t size);
         void* memalign_pool(std::size_t align, std::size_t size);
-
         
+        /**
+         * Return the memory resource used to allocate memory for the pool.
+         */
         inline std::pmr::memory_resource* pool_resource() const {  return this->upstream; }
+
         inline bool is_allocated() const { return this->memory_pool != nullptr; }
+        /**
+         * Equality comparison is true only if the compared object has the same memory pool.
+         */
         inline bool operator==(const tlsf_pool& other) const {
             return this->memory_pool == other.memory_pool && this->memory_pool != nullptr;
         }
-    
-    private:
         
+        /**
+         * Return the amount of memory available for allocation.
+         */
+        inline std::size_t size() {return this->pool_size;}
+        /**
+         * Return the total amount of memory allocated for tlsf_pool.
+         */
+        inline std::size_t allocation_size() {return this->allocated_size;}
+        
+    private:
+        /**
+         * @brief Main constructor for `tlsf_pool`. Constructors are private so that pool initialization has to 
+         * go through the `create` method, which can fail. 
+         */
+        explicit tlsf_pool(std::size_t bytes, std::pmr::memory_resource* upstream);
+        explicit tlsf_pool(std::size_t bytes){ this->initialize(bytes); }
+        explicit tlsf_pool() { this->initialize(DEFAULT_POOL_SIZE); }
+        explicit tlsf_pool(pool_options options) : upstream(options.upstream_resource) 
+        {this->initialize(options.size); }
+            
         using tlsfptr_t = ptrdiff_t;
        
         static constexpr std::size_t POOL_OVERHEAD = 2*detail::BLOCK_HEADER_OVERHEAD;

--- a/src/synchronized_tlsf_resource.cpp
+++ b/src/synchronized_tlsf_resource.cpp
@@ -3,21 +3,10 @@
 namespace tlsf {
 
 void* synchronized_tlsf_resource::do_allocate(std::size_t bytes, std::size_t align) {
-    void* ptr;
-
     //if align is smaller than block alignment, any allocation 
     //will already be aligned with the desired alignment. 
     this->mutex.lock();
-    if (align <= detail::ALIGN_SIZE){
-        ptr = this->memory_pool.malloc_pool(bytes);
-    } else {
-        ptr = this->memory_pool.memalign_pool(align, bytes);
-    }
-
-    //if nullptr is returned, allocation has failed. Defer to upstream resource. 
-    if (ptr == nullptr && bytes > 0) {
-        ptr = this->upstream->allocate(bytes, align);
-    }
+    void* ptr = tlsf_resource::do_allocate(bytes, align);
     this->mutex.unlock();
     return ptr;
 }
@@ -26,39 +15,9 @@ void synchronized_tlsf_resource::do_deallocate(void* p, std::size_t bytes, std::
     //The size to be deallocated is already known in the block, so the byte count and 
     //alignment values are not needed.
     this->mutex.lock();
-    if (!this->memory_pool.free_pool(p)){
-        this->upstream->deallocate(p, bytes, align);
-    }
+    tlsf_resource::do_deallocate(p, bytes, align);
     this->mutex.unlock();
 }
 
-/**
- * @brief A tlsf resource is considered equal to another if they both point to the same memory pool. 
- * Because the allocation is done internally, this effectively means that a `synchronized_tlsf_resource` is only equal to itself.
- * 
- * @param other 
- * @return true 
- * @return false 
- */
-bool synchronized_tlsf_resource::do_is_equal(const synchronized_tlsf_resource& other) const noexcept {
-    return this->memory_pool == other.memory_pool;
-}
 
-/**
- * @brief Determine whether the two memory resources point to the same memory pool. For upcasted pointers,
- * this requires RTTI in order to make a determination, as the underlying resource needs to be a `synchronized_tlsf_resource`
- * in order for the comparison to be meaningful. If RTTI is disabled, then this always returns false.
- * 
- * @param other  
- * @return Whether the resources point to the same memory pool. If the other resource is not a tlsf resource, always returns false.
- */
-bool synchronized_tlsf_resource::do_is_equal(const std::pmr::memory_resource& other) const noexcept {
-    #ifdef __GXX_RTTI
-        const auto cast = dynamic_cast<const synchronized_tlsf_resource*>(&other);
-        return cast ? this->memory_pool == cast->memory_pool : false;
-    #else
-        return false;
-    #endif
-}
-
-}
+} //namespace tlsf

--- a/src/synchronized_tlsf_resource.hpp
+++ b/src/synchronized_tlsf_resource.hpp
@@ -23,13 +23,16 @@ namespace tlsf {
  */
 class synchronized_tlsf_resource: public std::pmr::memory_resource {
        public:
-
+    //constructors
         explicit synchronized_tlsf_resource(std::size_t size) : memory_pool(size) {}
         explicit synchronized_tlsf_resource() noexcept: memory_pool() {}
         explicit synchronized_tlsf_resource(std::size_t size, std::pmr::memory_resource* upstream): memory_pool(size), upstream(upstream) {}
         explicit synchronized_tlsf_resource(pool_options options): memory_pool(options), upstream(options.upstream_resource) {}
         explicit synchronized_tlsf_resource(pool_options options, std::pmr::memory_resource* upstream): memory_pool(options), upstream(upstream) {}
-        explicit synchronized_tlsf_resource(const synchronized_tlsf_resource& resource) noexcept: memory_pool(resource.memory_pool) {}
+
+    //copy construction is disabled for consistency with standard library pool resources
+        synchronized_tlsf_resource(const synchronized_tlsf_resource&) = delete;
+        synchronized_tlsf_resource& operator=(const synchronized_tlsf_resource&) = delete;
         
         inline std::pmr::memory_resource* upstream_resource() const { return this->upstream; }
 

--- a/src/tlsf_resource.cpp
+++ b/src/tlsf_resource.cpp
@@ -38,11 +38,13 @@ void tlsf_resource::release() {
     this->memory_pool.reset();
 }
 
-pool_options tlsf_resource::options() {
-    if (this->memory_pool)
-        return {this->memory_pool->allocation_size(), this->memory_pool->pool_resource()};
-    else 
-        return {0, nullptr};
+std::optional<pool_options> tlsf_resource::options() {
+    if (this->memory_pool) {
+        return pool_options{this->memory_pool->allocation_size(), this->memory_pool->pool_resource()};
+    }
+    else {
+        return std::nullopt;
+    }
 }
 
 void tlsf_resource::create_memory_pool(pool_options options, bool replace){

--- a/src/tlsf_resource.hpp
+++ b/src/tlsf_resource.hpp
@@ -14,13 +14,16 @@ namespace tlsf {
 class tlsf_resource : public std::pmr::memory_resource {
 
     public:
-
+    //constructors
         explicit tlsf_resource(std::size_t size) : memory_pool(size) {}
         explicit tlsf_resource() noexcept: memory_pool() {}
         explicit tlsf_resource(std::size_t size, std::pmr::memory_resource* upstream): memory_pool(size), upstream(upstream) {}
         explicit tlsf_resource(pool_options options): memory_pool(options), upstream(options.upstream_resource) {}
         explicit tlsf_resource(pool_options options, std::pmr::memory_resource* upstream): memory_pool(options), upstream(upstream) {}
-        explicit tlsf_resource(const tlsf_resource& resource) noexcept: memory_pool(resource.memory_pool) {}
+    
+    //copy construction is disabled for consistency with standard library pool resources
+        tlsf_resource(const tlsf_resource&) = delete;
+        tlsf_resource& operator=(const tlsf_resource&) = delete;
 
         inline std::pmr::memory_resource* upstream_resource() const { return this->upstream; }
 

--- a/src/tlsf_resource.hpp
+++ b/src/tlsf_resource.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory_resource>
-#include <cstddef>
+#include <optional>
 #include "pool.hpp"
 
 namespace tlsf {
@@ -15,19 +15,56 @@ class tlsf_resource : public std::pmr::memory_resource {
 
     public:
     //constructors
-        explicit tlsf_resource(std::size_t size) : memory_pool(size) {}
-        explicit tlsf_resource() noexcept: memory_pool() {}
-        explicit tlsf_resource(std::size_t size, std::pmr::memory_resource* upstream): memory_pool(size), upstream(upstream) {}
-        explicit tlsf_resource(pool_options options): memory_pool(options), upstream(options.upstream_resource) {}
-        explicit tlsf_resource(pool_options options, std::pmr::memory_resource* upstream): memory_pool(options), upstream(upstream) {}
+        explicit tlsf_resource() noexcept {}
+        /**
+         * @brief Construct a TLSF memory resource.
+         * 
+         * @throws `std::runtime_error` if the memory pool is unable to initialize. 
+         */
+        explicit tlsf_resource(
+            std::size_t size, 
+            std::pmr::memory_resource* upstream = std::pmr::null_memory_resource())
+            : upstream(upstream) {this->initialize_memory_pool(size);}
+        
+        explicit tlsf_resource(
+            pool_options options, 
+            std::pmr::memory_resource* upstream = std::pmr::null_memory_resource())
+            : upstream(upstream) {this->initialize_memory_pool(options.size, options.upstream_resource);}
     
     //copy construction is disabled for consistency with standard library pool resources
         tlsf_resource(const tlsf_resource&) = delete;
         tlsf_resource& operator=(const tlsf_resource&) = delete;
 
         inline std::pmr::memory_resource* upstream_resource() const { return this->upstream; }
+        
+        /**
+         * @brief Releases all allocated memory owned by this resource.
+         * 
+         * @warning This will deallocate the underlying memory pool. If there are objects 
+         * with memory allocated by the pool still in scope, this will result in dangling pointers!
+         */
+        void release();
 
-    private:
+        /**
+         * @brief Returns pool options that determine the allocation behavior of this resource.
+         */
+        pool_options options();
+
+        /**
+         * @brief Allocate a new memory pool for this memory resource using `options`. If `replace` is `True`, then
+         * any pre-existing memory pool for this resource is deallocated in the process.
+         * 
+         * @warning Deallocating a memory pool while objects allocated by it 
+         * are still in scope will result in dangling pointers!
+         * 
+         * @throws `std::runtime_error` if `replace` is `false` and there is a memory pool already allocated.
+         */
+        void create_memory_pool(pool_options options, bool replace = false);
+
+    protected:
+        void initialize_memory_pool(
+            std::size_t size, 
+            std::pmr::memory_resource* upstream = std::pmr::new_delete_resource());
 
         //overridden functions    
         void* do_allocate(std::size_t bytes, std::size_t alignment) override;
@@ -36,8 +73,9 @@ class tlsf_resource : public std::pmr::memory_resource {
         bool do_is_equal(const tlsf_resource& other) const noexcept;
         bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override;
 
-        tlsf_pool memory_pool;   
-        std::pmr::memory_resource* upstream = std::pmr::null_memory_resource();
+
+        std::optional<tlsf_pool> memory_pool;   
+        std::pmr::memory_resource* upstream;
 };
 
 } //namespace tlsf

--- a/src/tlsf_resource.hpp
+++ b/src/tlsf_resource.hpp
@@ -46,9 +46,15 @@ class tlsf_resource : public std::pmr::memory_resource {
         void release();
 
         /**
-         * @brief Returns pool options that determine the allocation behavior of this resource.
+         * @brief Returns pool options that determine the allocation behavior of this resource. Empty if
+         * no underlying memory pool has been allocated. 
          */
-        pool_options options();
+        std::optional<pool_options> options();
+        
+        /**
+         * @brief Returns whether the resource has an allocated memory pool or not.
+         */
+        inline bool has_pool() { return this->memory_pool.has_value();}
 
         /**
          * @brief Allocate a new memory pool for this memory resource using `options`. If `replace` is `True`, then

--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -1,52 +1,57 @@
 #include <gtest/gtest.h>
 #include "pool.hpp"
+#include <optional>
 
 using namespace tlsf;
 
 class PoolTests : public ::testing::Test {
     protected:
-        PoolTests(): pool(1024*1024) {}
-        tlsf_pool pool;    
+        PoolTests(): pool(tlsf_pool::create(1024*1024)) {}
+        std::optional<tlsf_pool> pool;    
 };
 
 
-
 TEST_F(PoolTests, poolAllocatesOnConstruction){
-    EXPECT_TRUE(pool.is_allocated());
+    ASSERT_TRUE(pool);
+    EXPECT_TRUE(pool->is_allocated());
 }
 
 TEST_F(PoolTests, poolMalloc){
     using namespace tlsf::detail;
-    void* bytes_1024 = pool.malloc_pool(1024);
+    void* bytes_1024 = pool->malloc_pool(1024);
     block_header* header = block_header::from_void_ptr(bytes_1024);
     ASSERT_EQ(header->get_size(), 1024);
     EXPECT_TRUE(bytes_1024);
-    EXPECT_TRUE(pool.free_pool(bytes_1024));
-    void* bytes_1024_2 = pool.malloc_pool(1024);
+    EXPECT_TRUE(pool->free_pool(bytes_1024));
+    void* bytes_1024_2 = pool->malloc_pool(1024);
     EXPECT_TRUE(bytes_1024_2);
-    EXPECT_TRUE(pool.free_pool(bytes_1024_2));
+    EXPECT_TRUE(pool->free_pool(bytes_1024_2));
     
-    void* bytes_1MB = pool.malloc_pool(1024*1024/2);
+    void* bytes_1MB = pool->malloc_pool(1024*1024/2);
     header = block_header::from_void_ptr(bytes_1MB);
     ASSERT_EQ(header->get_size(), 1024*1024/2);
     EXPECT_TRUE(bytes_1MB);
-    pool.free_pool(bytes_1MB);
+    pool->free_pool(bytes_1MB);
     
-    void* bytes_toomany = pool.malloc_pool(1024*1024 + 1);
+    void* bytes_toomany = pool->malloc_pool(1024*1024 + 1);
     EXPECT_FALSE(bytes_toomany);
 }
 
 TEST(PoolDeathTest, poolDeallocatesOnDestruction){
     {
-        tlsf_pool pool(1024*1024);
-        void* bytes = pool.malloc_pool(2048);
-        EXPECT_TRUE(pool.free_pool(bytes));
-        void* bytes2 = pool.memalign_pool(2048, 32);
-        EXPECT_TRUE(pool.free_pool(bytes2));
+        auto pool = tlsf_pool::create(1024*1024);
+        ASSERT_TRUE(pool.has_value());
+        ASSERT_TRUE(pool->is_allocated());
+        void* bytes = pool->malloc_pool(2048);
+        EXPECT_TRUE(bytes);
+        EXPECT_TRUE(pool->free_pool(bytes));
+        void* bytes2 = pool->memalign_pool(2048, 32);
+        EXPECT_TRUE(bytes2);
+        EXPECT_TRUE(pool->free_pool(bytes2));
     }
 
     {
-        tlsf_pool pool(1024*1024);
+        auto pool = tlsf_pool::create(1024*1024);
     }
 }
 


### PR DESCRIPTION
This updates the public API of `tlsf_resource` to be more consistent with `std::pmr::unsynchronized_pool_resource`. It also removes debug print statements and harmonizes error handling: `tlsf_pool` uses C-style nullable return values for low-level, deterministic error handling, while `tlsf_resource` throws exceptions like the standard library.

To this end, `tlsf_pool` is now constructed using a static `create` method so that success can be reported in a return value, since a constructor cannot return anything. This required changing a few details of `tlsf_pool` constructors, like implementing a move constructor. 