### PR TITLE
Safe casts

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -242,7 +242,7 @@ void const* block_header::to_void_ptr() const {
  */
 block_header* block_header::from_void_ptr(const void* ptr){
     //note the intermediate conversion to unsigned char ptr is to get 1-byte arithmetic.
-    const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(ptr);
+    const uint8_t* byte_ptr = static_cast<const uint8_t*>(ptr);
     return reinterpret_cast<block_header*>(const_cast<uint8_t*>(byte_ptr) - BLOCK_START_OFFSET);
     // return TLSF_CAST(block_header*, TLSF_CAST(unsigned char*, ptr) - BLOCK_START_OFFSET);
 }
@@ -257,7 +257,7 @@ block_header* block_header::from_void_ptr(const void* ptr){
  * @return block_header* 
  */
 block_header* block_header::offset_to_block(const void* ptr, tlsfptr_t blk_size){
-    const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(ptr);
+    const uint8_t* byte_ptr = static_cast<const uint8_t*>(ptr);
     const uint8_t* new_address = byte_ptr + blk_size;
 
     return reinterpret_cast<block_header*>(const_cast<uint8_t*>(new_address));

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -58,13 +58,13 @@ int tlsf_fls(unsigned int word){
 // }
 
 int tlsf_fls_sizet(size_t size){
-    int high = (int)(size >> 32);
+    int high = static_cast<int>(size >> 32);
     int bits = 0;
     if (high) {
         bits = 32 + tlsf_fls(high);
     } 
     else {
-        bits = tlsf_fls((int)size & 0xffffffff);
+        bits = tlsf_fls(static_cast<int>(size) & 0xffffffff);
     }
     return bits; 
 }

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -6,9 +6,6 @@
 namespace tlsf {
 namespace detail {
 
-//More ergonomic cast
-//TODO: may want to change this to reinterpret_cast or static_cast depending on context. 
-#define TLSF_CAST(t, exp) ((t)(exp))
 
 /**
  * use builtin function to count leading zeroes of a bitmap.
@@ -125,11 +122,11 @@ void mapping_insert(std::size_t size, int* fli, int* sli){
     int fl, sl;
     if (size < SMALL_BLOCK_SIZE){
         fl = 0;
-        sl = TLSF_CAST(int, size) / (SMALL_BLOCK_SIZE/SL_INDEX_COUNT);
+        sl = static_cast<int>(size) / (SMALL_BLOCK_SIZE/SL_INDEX_COUNT);
     }
     else {
         fl = tlsf_fls_sizet(size);
-        sl = TLSF_CAST(int, size >> (fl-SL_INDEX_COUNT_LOG2))^(1 << SL_INDEX_COUNT_LOG2);
+        sl = static_cast<int>(size >> (fl-SL_INDEX_COUNT_LOG2))^(1 << SL_INDEX_COUNT_LOG2);
         fl -= (FL_INDEX_SHIFT-1);
     }
     *fli = fl;
@@ -144,10 +141,11 @@ void mapping_insert(std::size_t size, int* fli, int* sli){
  * @return void* 
  */
 void* align_ptr(const void* ptr, std::size_t align){
-    const tlsfptr_t aligned = 
-        (TLSF_CAST(tlsfptr_t, ptr) + (align -1)) & ~(align-1);
+    const uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+    const uintptr_t aligned_val  = (ptr_val + (align - 1)) & ~(align -1);
+
     assert(0 == (align & (align-1)) && "must align to a power of two");
-    return TLSF_CAST(void*, aligned);
+    return reinterpret_cast<void*>(aligned_val);
 }
 
 /**
@@ -213,16 +211,27 @@ block_header* block_coalesce(block_header* prev, block_header* block){
 
 
 bool block_header::is_last() const { return this->get_size() == 0;}
-bool block_header::is_free() const { return TLSF_CAST(bool, this->size & BLOCK_HEADER_FREE_BIT);}
-bool block_header::is_prev_free() const { return TLSF_CAST(bool, this->size & BLOCK_HEADER_PREV_FREE_BIT);}
+bool block_header::is_free() const { return static_cast<bool>(this->size & BLOCK_HEADER_FREE_BIT);}
+bool block_header::is_prev_free() const { return static_cast<bool>(this->size & BLOCK_HEADER_PREV_FREE_BIT);}
 bool block_header::can_split(std::size_t size) const { return this->get_size() >= sizeof(block_header) + size; }
 /**
  * @brief Obtain a pointer to the raw memory inside the block, skipping past the block header.
  * 
  * @return void* 
  */
-void* block_header::to_void_ptr() const {
-    return TLSF_CAST(void*, TLSF_CAST(uint8_t*, this) + BLOCK_START_OFFSET);
+void* block_header::to_void_ptr() {
+    uint8_t* offset_ptr = reinterpret_cast<uint8_t*>(this);
+    return offset_ptr + BLOCK_START_OFFSET;
+}
+
+/**
+ * @brief Obtain a pointer to the raw memory inside the block, skipping past the block header.
+ * 
+ * @return void* 
+ */
+void const* block_header::to_void_ptr() const {
+    uint8_t const* offset_ptr = reinterpret_cast<uint8_t const*>(this);
+    return offset_ptr + BLOCK_START_OFFSET;
 }
 
 /**
@@ -233,7 +242,9 @@ void* block_header::to_void_ptr() const {
  */
 block_header* block_header::from_void_ptr(const void* ptr){
     //note the intermediate conversion to unsigned char ptr is to get 1-byte arithmetic.
-    return TLSF_CAST(block_header*, TLSF_CAST(unsigned char*, ptr) - BLOCK_START_OFFSET);
+    const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(ptr);
+    return reinterpret_cast<block_header*>(const_cast<uint8_t*>(byte_ptr) - BLOCK_START_OFFSET);
+    // return TLSF_CAST(block_header*, TLSF_CAST(unsigned char*, ptr) - BLOCK_START_OFFSET);
 }
 
 /**
@@ -246,9 +257,10 @@ block_header* block_header::from_void_ptr(const void* ptr){
  * @return block_header* 
  */
 block_header* block_header::offset_to_block(const void* ptr, tlsfptr_t blk_size){
-    auto result = TLSF_CAST(block_header*, TLSF_CAST(tlsfptr_t, ptr)+blk_size);
-    // fprintf(stderr, "Address of header: %p\n", result);
-    return result;
+    const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(ptr);
+    const uint8_t* new_address = byte_ptr + blk_size;
+
+    return reinterpret_cast<block_header*>(const_cast<uint8_t*>(new_address));
 }
 
 void block_header::mark_as_free() {

--- a/src/block.hpp
+++ b/src/block.hpp
@@ -139,7 +139,10 @@ struct block_header {
     bool is_free() const;
     bool is_prev_free() const;
     bool can_split(std::size_t size) const;
-    void* to_void_ptr() const;
+    
+    void* to_void_ptr();
+    void const* to_void_ptr() const;
+
     static block_header* from_void_ptr(const void* ptr);
     static block_header* offset_to_block(const void* ptr, tlsfptr_t blk_size);    
 

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -7,9 +7,6 @@
 #include <iostream>
 #include <memory_resource>
 
-// More ergonomic cast
-#define TLSF_CAST(t, exp) ((t)(exp))
-
 namespace tlsf {
 using namespace detail;
 
@@ -30,7 +27,7 @@ tlsf_pool::~tlsf_pool(){
 void tlsf_pool::initialize(std::size_t size){
     //TODO: currently this allocator uses malloc to allocate memory for the pool, 
     //but we should use some kind of function pointer or template instead to use other means of memory allocation.
-    this->memory_pool = (char*) this->upstream->allocate(size, ALIGN_SIZE);
+    this->memory_pool = static_cast<char*>(this->upstream->allocate(size, ALIGN_SIZE));
     this->allocated_size = size;
     //Create a reference null block. 
     //Pointing to this block will indicate that this block pointer is not assigned.
@@ -59,7 +56,7 @@ char* tlsf_pool::create_memory_pool(char* mem, std::size_t bytes){
     const std::size_t pool_bytes = align_down(bytes - POOL_OVERHEAD, ALIGN_SIZE);
     this->pool_size = pool_bytes;
 
-    if (((ptrdiff_t)mem % ALIGN_SIZE) != 0){
+    if ((reinterpret_cast<ptrdiff_t>(mem) % ALIGN_SIZE) != 0){
         //memory size is not aligned
         // fprintf(stderr,"tlsf init pool: Memory size must be aligned by %u bytes.\n", (unsigned int)ALIGN_SIZE);
         std::cerr << "tlsf init pool: Memory size must be aligned by " << static_cast<unsigned int>(ALIGN_SIZE) << " bytes.\n";
@@ -81,7 +78,7 @@ char* tlsf_pool::create_memory_pool(char* mem, std::size_t bytes){
     // so that the prev_phys_free_block field falls outside of the pool - 
     // it will never be used.
 
-    block = block_header::offset_to_block((void*)mem,-(ptrdiff_t)BLOCK_HEADER_OVERHEAD);
+    block = block_header::offset_to_block(static_cast<void*>(mem),-static_cast<ptrdiff_t>(BLOCK_HEADER_OVERHEAD));
     block->set_size(pool_bytes);
     block->set_free();
     block->set_prev_used();
@@ -364,8 +361,8 @@ bool tlsf_pool::free_pool(void* ptr){
         block_header* block = block_header::from_void_ptr(ptr);
         //need to ensure that the memory address is part of the memory pool
         //otherwise pool is not responsible for deallocating this ptr
-        if (TLSF_CAST(char*, block) > this->memory_pool + this->pool_size 
-            || TLSF_CAST(char*, block) < this->memory_pool )
+        if (reinterpret_cast<char*>(block) > this->memory_pool + this->pool_size 
+            || reinterpret_cast<char*>(block) < this->memory_pool )
                 return false;
         
         assert(!block->is_free() && "block already marked as free");
@@ -464,18 +461,18 @@ void* tlsf_pool::memalign_pool(std::size_t align, std::size_t size){
     if (block) {
         void* ptr = block->to_void_ptr();
         void* aligned = align_ptr(ptr, align);
-        size_t gap = TLSF_CAST(size_t, TLSF_CAST(tlsfptr_t, aligned)- TLSF_CAST(tlsfptr_t, ptr));
+        size_t gap = static_cast<size_t>(reinterpret_cast<tlsfptr_t>(aligned)- reinterpret_cast<tlsfptr_t>(ptr));
 
         // if gap size is too small, offset to next aligned boundary
         if (gap && gap < gap_minimum){
             const size_t gap_remain = gap_minimum - gap;
             const size_t offset = tlsf_max(gap_remain, align);
-            const void* next_aligned = TLSF_CAST(void*, 
-                TLSF_CAST(tlsfptr_t, aligned) + offset);
+            const void* next_aligned = reinterpret_cast<void*>(
+                reinterpret_cast<tlsfptr_t>(aligned) + offset);
             
             aligned = align_ptr(next_aligned, align);
-            gap = TLSF_CAST(size_t, 
-                TLSF_CAST(tlsfptr_t, aligned) -TLSF_CAST(tlsfptr_t, ptr));
+            gap = static_cast<size_t>( 
+                reinterpret_cast<tlsfptr_t>(aligned) -reinterpret_cast<tlsfptr_t>(ptr));
         }
 
         if (gap) {


### PR DESCRIPTION
Change most C-style casts to C++ casts for type safety.